### PR TITLE
chore: add protocol cname

### DIFF
--- a/protocols/compound/index.json
+++ b/protocols/compound/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "compound",
+  "cname": "compound",
   "name": "Compound",
   "description": "Compound is a decentralized money market protocol to borrow and lend assets.",
   "path": "compound",

--- a/protocols/compound/index.json
+++ b/protocols/compound/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "compound",
   "name": "Compound",
   "description": "Compound is a decentralized money market protocol to borrow and lend assets.",
   "path": "compound",

--- a/protocols/compoundgrants/index.json
+++ b/protocols/compoundgrants/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "compoundgrants",
   "name": "Compound Grants",
   "description": "The Compound Grants Program is a 4/7 multisig controlled committee that will deploy a maximum of $1mm per quarter and run for two quarters.",
   "path": "compoundgrants.eth",

--- a/protocols/compoundgrants/index.json
+++ b/protocols/compoundgrants/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "compoundgrants",
+  "cname": "compoundgrants",
   "name": "Compound Grants",
   "description": "The Compound Grants Program is a 4/7 multisig controlled committee that will deploy a maximum of $1mm per quarter and run for two quarters.",
   "path": "compoundgrants.eth",

--- a/protocols/defidollar/index.json
+++ b/protocols/defidollar/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "defidollar",
   "name": "DefiDollar DAO",
   "description": "DUSD is a stablecoin controlled by a DAO using DeFi primitives to remain pegged to the Dollar.",
   "path": "defidollar",

--- a/protocols/defidollar/index.json
+++ b/protocols/defidollar/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "defidollar",
+  "cname": "defidollar",
   "name": "DefiDollar DAO",
   "description": "DUSD is a stablecoin controlled by a DAO using DeFi primitives to remain pegged to the Dollar.",
   "path": "defidollar",

--- a/protocols/gnosis.eth/index.json
+++ b/protocols/gnosis.eth/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "gnosis",
+  "cname": "gnosis",
   "name": "Gnosis",
   "description": "GnosisDAO uses Gnosis products to transparently guide decisions on development, support, and governance of its token ecosystem.",
   "path": "gnosis.eth",

--- a/protocols/gnosis.eth/index.json
+++ b/protocols/gnosis.eth/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "gnosis",
   "name": "Gnosis",
   "description": "GnosisDAO uses Gnosis products to transparently guide decisions on development, support, and governance of its token ecosystem.",
   "path": "gnosis.eth",

--- a/protocols/indexCoop/index.json
+++ b/protocols/indexCoop/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "indexCoop",
+  "cname": "indexCoop",
   "name": "Index",
   "description": "The Index Coop is an autonomous asset manager governed, maintained, and upgraded by INDEX token holders.",
   "path": "index",

--- a/protocols/indexCoop/index.json
+++ b/protocols/indexCoop/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "indexCoop",
   "name": "Index",
   "description": "The Index Coop is an autonomous asset manager governed, maintained, and upgraded by INDEX token holders.",
   "path": "index",

--- a/protocols/rally/index.json
+++ b/protocols/rally/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "rally",
+  "cname": "rally",
   "name": "Rally",
   "description": "Rally is a decentralized network enabling creators to monetize and align themselves with their community.",
   "path": "rally",

--- a/protocols/rally/index.json
+++ b/protocols/rally/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "rally",
   "name": "Rally",
   "description": "Rally is a decentralized network enabling creators to monetize and align themselves with their community.",
   "path": "rally",

--- a/protocols/rarible/index.json
+++ b/protocols/rarible/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "rarible",
+  "cname": "rarible",
   "name": "Rarible",
   "description": "Rarible is the premiere NFT marketplace to mint, buy, and sell digital collectibles.",
   "path": "rarible",

--- a/protocols/rarible/index.json
+++ b/protocols/rarible/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "rarible",
   "name": "Rarible",
   "description": "Rarible is the premiere NFT marketplace to mint, buy, and sell digital collectibles.",
   "path": "rarible",

--- a/protocols/synthetix/index.json
+++ b/protocols/synthetix/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "synthetix",
+  "cname": "synthetix",
   "name": "Synthetix",
   "description": "Synthetix is a decentralised synthetic asset issuance protocol built on Ethereum.",
   "path": "snxgov.eth",

--- a/protocols/synthetix/index.json
+++ b/protocols/synthetix/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "synthetix",
   "name": "Synthetix",
   "description": "Synthetix is a decentralised synthetic asset issuance protocol built on Ethereum.",
   "path": "snxgov.eth",

--- a/protocols/uniswap/index.json
+++ b/protocols/uniswap/index.json
@@ -1,4 +1,5 @@
 {
+  "id": "uniswap",
   "name": "Uniswap",
   "description": "Uniswap is a decentralized protocol for automated liquidity provision on Ethereum.",
   "path": "uniswap",

--- a/protocols/uniswap/index.json
+++ b/protocols/uniswap/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "uniswap",
+  "cname": "uniswap",
   "name": "Uniswap",
   "description": "Uniswap is a decentralized protocol for automated liquidity provision on Ethereum.",
   "path": "uniswap",

--- a/protocols/yup.eth/index.json
+++ b/protocols/yup.eth/index.json
@@ -1,5 +1,5 @@
 {
-
+  "id": "yup",
   "name": "Yup",
   "description": "Your opinion matters. Curate the web. Earn & influence.",
   "path": "yup.eth",

--- a/protocols/yup.eth/index.json
+++ b/protocols/yup.eth/index.json
@@ -1,5 +1,5 @@
 {
-  "id": "yup",
+  "cname": "yup",
   "name": "Yup",
   "description": "Your opinion matters. Curate the web. Earn & influence.",
   "path": "yup.eth",

--- a/types.ts
+++ b/types.ts
@@ -1,7 +1,7 @@
 import * as t from "io-ts";
 
 export const ProtocolIo = t.type({
-  id: t.string,
+  cname: t.string,
   name: t.string,
   description: t.string,
   path: t.string,

--- a/types.ts
+++ b/types.ts
@@ -1,6 +1,7 @@
 import * as t from "io-ts";
 
 export const ProtocolIo = t.type({
+  id: t.string,
   name: t.string,
   description: t.string,
   path: t.string,


### PR DESCRIPTION
This PR defines a stable protocol `cname` (canonical name) for each protocol -- this field will be used to reference protocols in a consistent way across our repos.

@bvalosek and I had discussed instead labeling this field `slug`, which could be confusing with `path` already being a field, but open to thoughts on that.