### PR TITLE
chore: export compiled artifact

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,4 @@
-import { Protocol } from "./types";
-
-declare module "boardroomInfo" {
-  export = Protocol;
+declare module "@boardroom/protocol-info" {
+  function protocolInfo(): void;
+  export = protocolInfo;
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "@boardroom/protocol-info",
   "version": "2.1.2",
   "description": "Project information which will be served to display on the Boardroom Governance Portal.",
-  "main": "dist/index.ts",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
   "repository": "https://github.com/boardroom-inc/protocol-Info.git",
   "author": "sudheer <sudheer.105@gmail.com>",
   "license": "MIT",
@@ -18,7 +19,7 @@
     "typescript": "^4.1.3"
   },
   "scripts": {
-    "build": "ts-node ./scripts/build.ts",
+    "build": "ts-node ./scripts/build.ts && tsc -d",
     "prepare": "yarn build",
     "validate": "yarn build && ts-node ./scripts/validate.ts"
   }

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -8,9 +8,12 @@ const protocolInfo = protocols.map((protocol) =>
 );
 
 mkdirp.sync("./dist");
-fs.copyFileSync("./index.d.ts", "./dist/index.d.ts");
 fs.copyFileSync("./types.ts", "./dist/types.ts");
 fs.writeFileSync(
   "./dist/index.ts",
-  `export default [${protocolInfo.toString()}];`
+  `
+  import { Protocol } from "../types";
+
+  export default [${protocolInfo.toString()}] as Protocol[];
+  `
 );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es5",
     "module": "commonjs",
-    "outDir": "dist",
+    "outDir": ".",
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
@@ -10,5 +10,7 @@
     "forceConsistentCasingInFileNames": true,
     "esModuleInterop": true,
     "resolveJsonModule": true
-  }
+  },
+  "include": ["./dist"],
+  "exclude": ["./node_modules"]
 }


### PR DESCRIPTION
This PR updates the build to export a CommonJS module for easier consumption by consumers while maintaining type safety in exports.