### PR TITLE
chore: update rally snapshot space name

### DIFF
--- a/protocols/rally/index.json
+++ b/protocols/rally/index.json
@@ -12,7 +12,7 @@
   "hasOnchain": false,
   "isHybrid": false,
   "hasDelegation": false,
-  "snapshotSpaceName": "rally",
+  "snapshotSpaceName": "rallygov.eth",
   "invalidSnapshots": [],
   "branding": {},
   "discourseForum": {},


### PR DESCRIPTION
Rally changed their snapshot space name, which breaks our Rally proposal stats and list: https://snapshot.org/#/rallygov.eth