### PR TITLE
chore: revert powerpool claim

### DIFF
--- a/protocols/powerpool/index.json
+++ b/protocols/powerpool/index.json
@@ -9,12 +9,12 @@
 	"suffix": "CVP",
 	"coinGeckoPriceString": "powerpool-concentrated-voting-power",
 	"tokenContractAddress": "0x38e4adb44ef08f22f5b5b76a8f0c2d0dcbe7dca1",
-	"isEnabled": true,
+	"isEnabled": false,
 	"hasOnchain": false,
 	"claim": {
-		"isClaimed": true,
-		"claimer": "0x2339e475b7458261a0ef97d2836a99b9e890581e",
-		"signature": "0x3082f6bbba76c5362e85ae5b6ee32345f399df989a21831fa51018b37adf74ff23cc0bab23306fff37c8429168df8e62b1d85e9d84dae19911bc6081e20d4d3e1c"
+		"isClaimed": false,
+		"claimer": "",
+		"signature": ""
 	},
 	"isHybrid": false,
 	"hasDelegation": false,


### PR DESCRIPTION
This PR reverts the Powerpool claim to unblock us from consuming new versions of this package in `hub-ui`.