### PR TITLE
chore: update index snapshot name

### DIFF
--- a/protocols/indexCoop/index.json
+++ b/protocols/indexCoop/index.json
@@ -17,7 +17,7 @@
     "claimer": "",
     "signature": ""
   },
-  "snapshotSpaceName": "index",
+  "snapshotSpaceName": "index-coop.eth",
   "invalidSnapshots": [
     "QmQ2s6DsA2jc7ops9BC2KzQwo4rYZLYavisLJvLihpTGvH"
   ],


### PR DESCRIPTION
This PR updates the Index snapshot name to `index-coop.eth`: https://snapshot.org/#/index-coop.eth