### PR TITLE
fix: disable aave and instadapp treasury nav

### DIFF
--- a/protocols/aave/index.json
+++ b/protocols/aave/index.json
@@ -24,5 +24,6 @@
 		"categoryId": ""
 	},
 	"safeAddress": null,
-	"treasuryAddresses": ["0x25F2226B597E8F9514B3F68F00f494cF4f286491"] 
+	"treasuryAddresses": ["0x25F2226B597E8F9514B3F68F00f494cF4f286491"],
+	"disableTreasuryNav": true
 }

--- a/protocols/instadapp/index.json
+++ b/protocols/instadapp/index.json
@@ -18,5 +18,6 @@
     "categoryId": "5"
   },
   "treasuryAddress": "0x28849D2b63fA8D361e5fc15cB8aBB13019884d09",
-  "safeAddress": null
+  "safeAddress": null,
+  "disableTreasuryNav": true
 }


### PR DESCRIPTION
This PR ensures the Treasury navigation link in the sidebar does not show up for Aave and Instadapp.