### PR TITLE
chore: remove protocol type field

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ $ yarn link @boardroom/protocol-info
 
 Quick Add New Protocol:
 ```sh
-$ ./scripts/add_new_protocol $protocolName $tokenContractAddress (optional) $suffix (optional) $displayName (optional)
+$ ./scripts/add_new_protocol $protocolName
 ```
 
 Run validation:

--- a/protocols/603M.legt.eth/index.json
+++ b/protocols/603M.legt.eth/index.json
@@ -2,6 +2,5 @@
   "cname": "603M.legt",
   "description": "DAO for the property at 603 Miramar",
   "path": "example",
-  "type": "snapshot",
   "isEnabled": true
 }

--- a/protocols/API3/index.json
+++ b/protocols/API3/index.json
@@ -2,6 +2,5 @@
 	"cname": "api3",
 	"description": "",
 	"path": "api3",
-	"type": "compoundish",
 	"isEnabled": true
 }

--- a/protocols/__example/index.json
+++ b/protocols/__example/index.json
@@ -2,6 +2,5 @@
   "cname": "example",
   "description": "A concise description of the protocol",
   "path": "example",
-  "type": "snapshot",
   "isEnabled": true
 }

--- a/protocols/aave/index.json
+++ b/protocols/aave/index.json
@@ -2,7 +2,6 @@
 	"cname": "aave",
 	"description": "",
 	"path": "aave",
-	"type": "others",
 	"isEnabled": true,
 	"treasuryAddresses": ["0x25F2226B597E8F9514B3F68F00f494cF4f286491"],
 	"disableTreasuryNav": true

--- a/protocols/aavegotchi.eth/index.json
+++ b/protocols/aavegotchi.eth/index.json
@@ -2,7 +2,6 @@
 	"cname": "aavegotchi",
 	"description": "",
 	"path": "aavegotchi.eth",
-	"type": "snapshot",
 	"isEnabled": true,
 	"discourseForum": {
 		"url": "https://dao.aavegotchi.com",

--- a/protocols/ampleforth/index.json
+++ b/protocols/ampleforth/index.json
@@ -2,6 +2,5 @@
 	"cname": "ampleforth",
 	"description": "",
 	"path": "ampleforth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/aragon/index.json
+++ b/protocols/aragon/index.json
@@ -2,6 +2,5 @@
 	"cname": "aragon",
 	"description": "",
 	"path": "aragon",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/badgerdao.eth/index.json
+++ b/protocols/badgerdao.eth/index.json
@@ -2,7 +2,6 @@
 	"cname": "badgerdao",
 	"description": "",
 	"path": "badgerdao.eth",
-	"type": "snapshot",
 	"isEnabled": true,
 	"treasuryAddresses": ["0x4441776e6a5d61fa024a5117bfc26b953ad1f425"]
 }

--- a/protocols/balancer/index.json
+++ b/protocols/balancer/index.json
@@ -2,6 +2,5 @@
 	"cname": "balancer",
 	"description": "",
 	"path": "balancer",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/banklessvault.eth/index.json
+++ b/protocols/banklessvault.eth/index.json
@@ -2,7 +2,6 @@
 	"cname": "banklessvault",
 	"description": "A decentralized community focused on one mission: help the world go bankless",
 	"path": "banklessvault.eth",
-	"type": "snapshot",
 	"isEnabled": true,
 	"discourseForum": {
 		"url": "https://forum.bankless.community/",

--- a/protocols/barnbridge/index.json
+++ b/protocols/barnbridge/index.json
@@ -2,7 +2,6 @@
   "cname": "barnbridge",
   "description": "BarnBridge is a decentralised finance (DeFi) risk tokenizing protocol. It aims to reduce the risks associated with DeFi, such as inflation risk, market price risk, and cash-flow volatility risk.",
   "path": "barnbridge",
-  "type": "compoundish",
   "isEnabled": false,
   "discourseForum": {
     "url": "https://forum.barnbridge.com/",

--- a/protocols/basisdollar.eth/index.json
+++ b/protocols/basisdollar.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "basisdollar",
 	"description": "",
 	"path": "basisdollar.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/buzzedbearhideout/index.json
+++ b/protocols/buzzedbearhideout/index.json
@@ -2,7 +2,6 @@
   "cname": "buzzedbearhideout",
   "description": "DeFi meets NFTs. Interest BEARing NFT.",
   "path": "buzzed",
-  "type": "snapshot",
   "isEnabled": true,
   "discourseForum": {
     "url": "https://gov.buzzedbearhideout.com/",

--- a/protocols/clean-city-guild/index.json
+++ b/protocols/clean-city-guild/index.json
@@ -2,6 +2,5 @@
   "cname": "clean-city-guild",
   "description": "DAO to bring people and communities together to keep cities clean",
   "path": "clean-city-guild",
-  "type": "snapshot",
   "isEnabled": true
 }

--- a/protocols/compound/index.json
+++ b/protocols/compound/index.json
@@ -2,7 +2,6 @@
   "cname": "compound",
   "description": "Compound is a decentralized money market protocol to borrow and lend assets.",
   "path": "compound",
-  "type": "compoundish",
   "isEnabled": true,
   "treasuryAddresses": ["0x3d9819210a31b4961b30ef54be2aed79b9c9cd3b", "0x2775b1c75658Be0F640272CCb8c72ac986009e38"],
   "disableTreasuryNav": true

--- a/protocols/compoundgrants/index.json
+++ b/protocols/compoundgrants/index.json
@@ -2,7 +2,6 @@
   "cname": "compoundgrants",
   "description": "The Compound Grants Program is a 4/7 multisig controlled committee that will deploy a maximum of $1mm per quarter and run for two quarters.",
   "path": "compoundgrants.eth",
-  "type": "snapshot",
   "isEnabled": true,
   "safeAddress": "0xF1D8c2eED95D5fC2EaDe4E6Bb15a5969453E89a9"
 }

--- a/protocols/council.graphprotocol.eth/index.json
+++ b/protocols/council.graphprotocol.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "thegraphcouncil",
 	"description": "",
 	"path": "council.graphprotocol.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/cream-finance.eth/index.json
+++ b/protocols/cream-finance.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "creamfinance",
 	"description": "",
 	"path": "cream-finance.eth",
-	"type": "snapshot",
 	"isEnabled": false
 }

--- a/protocols/crypto-corgis.eth/index.json
+++ b/protocols/crypto-corgis.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "cryptocorgis",
 	"description": "",
 	"path": "crypto-corgis.eth",
-	"type": "snapshot",
 	"isEnabled": false
 }

--- a/protocols/dai-prize-pool/index.json
+++ b/protocols/dai-prize-pool/index.json
@@ -2,6 +2,5 @@
 	"cname": "daiprizepool",
 	"description": "",
 	"path": "dai-prize-pool",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/daosquare/index.json
+++ b/protocols/daosquare/index.json
@@ -2,6 +2,5 @@
 	"cname": "daosquare",
 	"description": "",
 	"path": "daosquare",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/decentralgames.eth/index.json
+++ b/protocols/decentralgames.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "decentralgames",
 	"description": "",
 	"path": "decentralgames.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/defidollar/index.json
+++ b/protocols/defidollar/index.json
@@ -2,6 +2,5 @@
   "cname": "defidollar",
   "description": "DUSD is a stablecoin controlled by a DAO using DeFi primitives to remain pegged to the Dollar.",
   "path": "defidollar",
-  "type": "snapshot",
   "isEnabled": true
 }

--- a/protocols/drc/index.json
+++ b/protocols/drc/index.json
@@ -2,7 +2,6 @@
   "cname": "drc",
   "description": "Digital Reserve Currency was designed to become a decentralized digital store of value with a limited supply and a zero inflation rate. 1 billion indivisible DRC Tokens. Simplicity is the ultimate sophistication.",
   "path": "drc",
-  "type": "snapshot",
   "isEnabled": true,
   "safeAddress": "0x356B82b7A235242F578883132a60b7D8017900AF",
   "treasuryAddresses": ["0x356B82b7A235242F578883132a60b7D8017900AF"]

--- a/protocols/dsd.eth/index.json
+++ b/protocols/dsd.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "dsd",
 	"description": "",
 	"path": "dsd.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/esd.eth/index.json
+++ b/protocols/esd.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "esd",
 	"description": "",
 	"path": "esd.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/fei/index.json
+++ b/protocols/fei/index.json
@@ -2,7 +2,6 @@
 	"cname": "fei",
 	"description": "",
 	"path": "fei",
-	"type": "compoundish",
 	"isEnabled": true,
 	"treasuryAddresses": ["0x8d5ED43dCa8C2F7dFB20CF7b53CC7E593635d7b9"],
 	"disableTreasuryNav": true

--- a/protocols/frontier/index.json
+++ b/protocols/frontier/index.json
@@ -2,6 +2,5 @@
 	"cname": "frontier",
 	"description": "",
 	"path": "frontier",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/gitcoin/index.json
+++ b/protocols/gitcoin/index.json
@@ -2,7 +2,6 @@
 	"cname": "gitcoin",
 	"description": "Gitcoin is a blockchain-based incentivization layer for open source software.",
 	"path": "gitcoin",
-	"type": "compoundish",
 	"isEnabled": true,
   	"disableTreasuryNav": true
 }

--- a/protocols/gnosis.eth/index.json
+++ b/protocols/gnosis.eth/index.json
@@ -2,6 +2,5 @@
   "cname": "gnosis",
   "description": "GnosisDAO uses Gnosis products to transparently guide decisions on development, support, and governance of its token ecosystem.",
   "path": "gnosis.eth",
-  "type": "snapshot",
   "isEnabled": true
 }

--- a/protocols/gov.dhedge.eth/index.json
+++ b/protocols/gov.dhedge.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "dhedge",
 	"description": "dHEDGE DAO Governance",
 	"path": "gov.dhedge.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/graphprotocol.eth/index.json
+++ b/protocols/graphprotocol.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "graphprotocol",
 	"description": "",
 	"path": "graphprotocol.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/idlefinance/index.json
+++ b/protocols/idlefinance/index.json
@@ -2,7 +2,6 @@
 	"cname": "idlefinance",
 	"description": "Yield aggregator and rebalancing protocol with high security standards and a product suite aimed at portfolio risk diversification and yield enanchement",
 	"path": "idlefinance",
-	"type": "compoundish",
 	"isEnabled": true,
 	"discourseForum": {
 		"url": "https://gov.idle.finance",

--- a/protocols/indexCoop/index.json
+++ b/protocols/indexCoop/index.json
@@ -2,7 +2,6 @@
   "cname": "indexCoop",
   "description": "The Index Coop is an autonomous asset manager governed, maintained, and upgraded by INDEX token holders.",
   "path": "index",
-  "type": "snapshot",
   "isEnabled": true,
   "discourseForum": {
     "url": "https://gov.indexcoop.com",

--- a/protocols/indexed/index.json
+++ b/protocols/indexed/index.json
@@ -2,7 +2,6 @@
 	"cname": "indexed",
 	"description": "",
 	"path": "indexed",
-	"type": "compoundish",
 	"isEnabled": true,
 	"disableTreasuryNav": true
 }

--- a/protocols/instadapp/index.json
+++ b/protocols/instadapp/index.json
@@ -2,7 +2,6 @@
   "cname": "instadapp",
   "description": "The open source middleware platform for decentralized finance applications",
   "path": "instadapp",
-  "type": "compoundish",
   "isEnabled": true,
   "discourseForum": {
     "url": "https://gov.instadapp.io",

--- a/protocols/inverse/index.json
+++ b/protocols/inverse/index.json
@@ -2,7 +2,6 @@
 	"cname": "inverse",
 	"description": "",
 	"path": "inverse",
-	"type": "compoundish",
 	"isEnabled": true,
   "disableTreasuryNav": true
 }

--- a/protocols/keep2r.eth/index.json
+++ b/protocols/keep2r.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "keep2r",
 	"description": "",
 	"path": "keep2r.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/kleros/index.json
+++ b/protocols/kleros/index.json
@@ -2,6 +2,5 @@
 	"cname": "kleros",
 	"description": "",
 	"path": "kleros",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/mstable/index.json
+++ b/protocols/mstable/index.json
@@ -2,6 +2,5 @@
 	"cname": "mstable",
 	"description": "mStable is building decentralised stable-value asset infrastructure for DeFi.",
 	"path": "mstable",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/pasta/index.json
+++ b/protocols/pasta/index.json
@@ -2,6 +2,5 @@
 	"cname": "pasta",
 	"description": "",
 	"path": "pasta.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/pickle/index.json
+++ b/protocols/pickle/index.json
@@ -2,6 +2,5 @@
 	"cname": "pickle",
 	"description": "",
 	"path": "pickle",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/pleasrdao/index.json
+++ b/protocols/pleasrdao/index.json
@@ -2,6 +2,5 @@
   "cname": "pleasrdao",
   "description": "a cartel of $PEEPS that aim to plz",
   "path": "pleasrdao.eth",
-  "type": "snapshot",
   "isEnabled": true
 }

--- a/protocols/pooltogether/index.json
+++ b/protocols/pooltogether/index.json
@@ -2,7 +2,6 @@
 	"cname": "pooltogether",
 	"description": "",
 	"path": "pooltogether",
-	"type": "compoundish",
 	"isEnabled": true,
 	"treasuryAddresses": ["0x42cd8312d2bce04277dd5161832460e95b24262e", "0x21950e281bde1714ffd1062ed17c56d4d8de2359"],
 	"disableTreasuryNav": true

--- a/protocols/powerpool/index.json
+++ b/protocols/powerpool/index.json
@@ -2,6 +2,5 @@
 	"cname": "powerpool",
 	"description": "PowerPool is a decentralized protocol for automatically managed token portfolios, and smart indices. The protocol uses capital stored in portfolios/indices for generating additional yield from staking, vaults, and meta-governance.",
 	"path": "powerpool",
-	"type": "snapshot",
 	"isEnabled": false
 }

--- a/protocols/premia.eth/index.json
+++ b/protocols/premia.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "premia",
 	"description": "",
 	"path": "premia.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/radicle/index.json
+++ b/protocols/radicle/index.json
@@ -2,7 +2,6 @@
 	"cname": "radicle",
 	"description": "",
 	"path": "radicle",
-	"type": "compoundish",
 	"isEnabled": true,
 	"disableTreasuryNav": true
 }

--- a/protocols/rally/index.json
+++ b/protocols/rally/index.json
@@ -3,6 +3,5 @@
   "description": "Rally is a decentralized network enabling creators to monetize and align themselves with their community.",
   "path": "rallygov.eth",
   "previousPaths": ["rally"],
-  "type": "snapshot",
   "isEnabled": true
 }

--- a/protocols/rari/index.json
+++ b/protocols/rari/index.json
@@ -2,6 +2,5 @@
 	"cname": "rari",
 	"description": "",
 	"path": "rari",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/rarible/index.json
+++ b/protocols/rarible/index.json
@@ -2,7 +2,6 @@
   "cname": "rarible",
   "description": "Rarible is the premiere NFT marketplace to mint, buy, and sell digital collectibles.",
   "path": "rarible",
-  "type": "snapshot",
   "isEnabled": true,
   "discourseForum": {
     "url": "https://gov.rarible.com",

--- a/protocols/seen/index.json
+++ b/protocols/seen/index.json
@@ -2,6 +2,5 @@
 	"cname": "seen",
 	"description": "",
 	"path": "seen",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/shapeshift/index.json
+++ b/protocols/shapeshift/index.json
@@ -2,7 +2,6 @@
   "cname": "shapeshift",
   "description": "ShapeShift is a borderless, cross-chain crypto trading platform and portfolio manager for user self-sovereignty.",
   "path": "shapeshift",
-  "type": "snapshot",
   "isEnabled": true,
   "discourseForum": {
     "url": "https://forum.shapeshift.com",

--- a/protocols/sushi/index.json
+++ b/protocols/sushi/index.json
@@ -2,7 +2,6 @@
   "cname": "sushi",
   "description": "Swap, earn, stack yields, lend, borrow, leverage all on one decentralized community driven platform.",
   "path": "sushi",
-  "type": "snapshot",
   "isEnabled": true,
   "discourseForum": {
     "url": "https://forum.sushi.com",

--- a/protocols/synthetix/index.json
+++ b/protocols/synthetix/index.json
@@ -2,7 +2,6 @@
   "cname": "synthetix",
   "description": "Synthetix is a decentralised synthetic asset issuance protocol built on Ethereum.",
   "path": "snxgov.eth",
-  "type": "snapshot",
   "isEnabled": true,
   "safeAddress": "0x438679ECE13EDB95aDD18Ed02dDbf5e2418FF730",
   "treasuryAddresses": ["0xEb3107117FEAd7de89Cd14D463D340A2E6917769", "0x86626E1BbBd0ce95ED52e0C5E19f371a6640B591"]

--- a/protocols/tecommons/index.json
+++ b/protocols/tecommons/index.json
@@ -2,7 +2,6 @@
   "cname": "token-engineering-commons",
   "description": "An open source and collectively governed project that aims to create a token economy that will accelerate the responsible & ethical creation of public goods within the TE community.",
   "path": "tecommons",
-  "type": "snapshot",
   "isEnabled": true,
   "discourseForum": {
     "url": "https://forum.tecommons.org",

--- a/protocols/tokenlon.eth/index.json
+++ b/protocols/tokenlon.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "tokenlon",
 	"description": "",
 	"path": "tokenlon.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/truefigov.eth/index.json
+++ b/protocols/truefigov.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "truefigov",
 	"description": "",
 	"path": "truefigov.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/uniswap/index.json
+++ b/protocols/uniswap/index.json
@@ -2,7 +2,6 @@
   "cname": "uniswap",
   "description": "Uniswap is a decentralized protocol for automated liquidity provision on Ethereum.",
   "path": "uniswap",
-  "type": "compoundish",
   "isEnabled": true,
   "treasuryAddresses": ["0x1a9c8182c09f50c8318d769245bea52c32be35bc", "0x4750c43867ef5f89869132eccf19b9b6c4286e1a"],
   "disableTreasuryNav": true

--- a/protocols/vsp.eth/index.json
+++ b/protocols/vsp.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "vsp",
 	"description": "",
 	"path": "vsp.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/yamv2/index.json
+++ b/protocols/yamv2/index.json
@@ -2,7 +2,6 @@
 	"cname": "yamv2",
 	"description": "",
 	"path": "yamv2",
-	"type": "snapshot",
 	"isEnabled": false,
 	"treasuryAddresses": ["0x97990B693835da58A281636296D2Bf02787DEa17", "0xd67c05523d8ec1c60760fd017ef006b9f6e496d0", "0x205cc7463267861002b27021c7108bc230603d0f", "0xd67c05523d8ec1c60760fd017ef006b9f6e496d0"]
 }

--- a/protocols/ybaby.eth/index.json
+++ b/protocols/ybaby.eth/index.json
@@ -2,6 +2,5 @@
 	"cname": "ybaby",
 	"description": "",
 	"path": "ybaby.eth",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/yfbeta/index.json
+++ b/protocols/yfbeta/index.json
@@ -2,6 +2,5 @@
 	"cname": "yfbeta",
 	"description": "",
 	"path": "yfbeta",
-	"type": "snapshot",
 	"isEnabled": true
 }

--- a/protocols/yup.eth/index.json
+++ b/protocols/yup.eth/index.json
@@ -2,7 +2,6 @@
   "cname": "yup",
   "description": "Your opinion matters. Curate the web. Earn & influence.",
   "path": "yup.eth",
-  "type": "snapshot",
   "isEnabled": true,
   "safeAddress": "0xbd5224f66D5ce49a8Afefc14a76248D158D14c6F"
 }

--- a/scripts/add_new_protocol.sh
+++ b/scripts/add_new_protocol.sh
@@ -12,9 +12,6 @@ else
 	mkdir -p ./protocols/$1/resources/calls
 	mkdir -p ./protocols/$1/resources/Gov Weekly
 	
-	mkdir -p ./protocols/$1/contracts
-	touch ./protocols/$1/contracts/token.json
-
 	touch ./protocols/$1/index.json
 	touch ./protocols/$1/events.json
 	touch ./protocols/$1/overview.md
@@ -23,8 +20,6 @@ printf '{
 	"cname": "'"$1"'",
 	"description": "",
 	"path": "'"$1"'",
-	"type": "snapshot",
-	"tokenContractAddress": "'"$2"'",
 	"isEnabled": false,
 }' >| ./protocols/$1/index.json
 		fi

--- a/types.ts
+++ b/types.ts
@@ -6,7 +6,6 @@ export const ProtocolIo = t.type({
   path: t.string,
   previousPaths: t.union([t.array(t.string), t.undefined]),
   folder: t.string,
-  type: t.union([t.literal("snapshot"), t.literal("compoundish"), t.literal("others")]),
   isEnabled: t.boolean,
   discourseForum: t.union([
     t.partial({


### PR DESCRIPTION
This PR removes the `type` field from protocols, as it's no longer needed by the **hub-ui** -- any framework or protocol-specific details or configuration are now expressed through [@boardroom/governance-sdk](https://github.com/boardroom-inc/governance-sdk) introspection.