### PR TITLE
Add Ampleforth protocol info

### DIFF
--- a/protocols/ampleforth/index.json
+++ b/protocols/ampleforth/index.json
@@ -1,6 +1,11 @@
 {
-	"cname": "ampleforth",
-	"description": "",
-	"path": "ampleforth",
-	"isEnabled": true
+  "cname": "ampleforth",
+  "description": "AMPL is the first rebasing currency of DeFi. It is an uncollateralized financial primitive with an elastic supply that adjusts each day according to demand in the marketplace. Like Bitcoin, AMPL is non-dilutive but it has a long-term unit of account that unlocks safe denomination in contracts, like debt.",
+  "path": "ampleforth",
+  "type": "compoundish",
+  "isEnabled": true,
+  "discourseForum": {
+    "url": "https://https://forum.ampleforth.org",
+    "categoryId": "6",
+  },
 }

--- a/protocols/ampleforth/overview.md
+++ b/protocols/ampleforth/overview.md
@@ -1,0 +1,20 @@
+AMPL is the first rebasing currency of DeFi. It is an uncollateralized financial primitive with an elastic supply that adjusts each day according to demand in the marketplace. AMPL targets the 2019 USD. Like Bitcoin, AMPL is non-dilutive but it has a long-term unit of account that unlocks safe denomination in contracts, like debt.
+
+Although not a stablecoin itself, AMPL can fulfill many of the same roles of a stablecoin without the associated risks. AMPL does not rely on centralized custodians, liquidation markets, or lenders of last resort. Thus AMPL is "durable" like Bitcoin. The goal of Ampleforth is to create a building block for a safer, more resilient financial ecosystem.
+
+#### About Ampleforth Governance
+The Ampleforth protocol is governed through a series of sequential steps, each representing increasing levels of consensus from the community. Proposals and ideas are surfaced on the discord or public forums, and are finalised when they are deployed onchain. For more details, please visit the [Ampleforth Governance](https://www.ampleforth.org/governance/) landing page.
+
+[FORTH](https://www.coingecko.com/en/coins/ampleforth-governance-token) is the governance token for the Ampleforth protocol.
+
+### Additional Resources
+
+* [Website](https://ampleforth.org)
+* [Twitter](https://twitter.com/ampleforthorg)
+* [Github](https://https://github.com/ampleforth)
+* [Discord Chat](https://discord.gg/6Amxhs4)
+* [Discourse Forum](https://forum.ampleforth.org/)
+* [Snapshot](https://signal.ampleforth.org)
+* [Blog](https://medium.com/ampleforth)
+* [AMPL Token Info](https://www.coingecko.com/en/coins/ampleforth)
+* [FORTH Token Info](https://www.coingecko.com/en/coins/ampleforth-governance-token)


### PR DESCRIPTION
I followed the guide [here](https://docs.boardroom.info/boardroom-portal-1/adding-your-project/protocol-information#overview)

but I don't see the URLs section in the Discord Admin settings referenced in [this step](https://docs.boardroom.info/boardroom-portal-1/adding-your-project/protocol-information#forum). Is that still required?