### PR TITLE
Chore: Edit overview content

### DIFF
--- a/protocols/bitdao/index.json
+++ b/protocols/bitdao/index.json
@@ -1,6 +1,6 @@
 {
   "cname": "bitdao",
-  "description": "Supporting the Builders of the Decentralized Economy",
+  "description": "BitDAO is a collective of builders and stakeholders enabling mutually beneficial Web3 ecosystems of people, products, and public goods.",
   "path": "bitdao",
   "isEnabled": true,
   "discourseForum": {

--- a/protocols/bitdao/overview.md
+++ b/protocols/bitdao/overview.md
@@ -5,7 +5,7 @@ Anyone can make a proposal to BitDAO and, through the governance process, BIT to
 ## An Accelerator for Autonomous Entities
 Autonomous Entities (AEs) are independent organizations that are funded from successful proposals to the BitDAO treasury and are focused on a particular product, use case, or industry. Examples of previously approved Autonomous Entities include [Game7](https://game7.io/), [zkDAO](https://zkdao.io/), and [EduDAO](https://edudao.io/).
 
-# **Governance Process**
+## **Governance Process**
 BitDAO is owned and governed by $BIT token holders. To reduce spam, 200k BIT is required to make a proposal and 100M BIT is required to approve it.
 
 ## Phase 1: Soft Proposal

--- a/protocols/bitdao/overview.md
+++ b/protocols/bitdao/overview.md
@@ -1,20 +1,20 @@
-**[BitDAO](https://www.bitdao.io/) believes DAOs can do more for industries like Art, Education, Media, Finance, Gaming, and Technology. And it's using its billions in existing assets and forecasted contributions to connect and empower the builders of the decentralized economy.**
+[BitDAO](https://www.bitdao.io/) believes DAOs can do more for industries like Art, Education, Media, Finance, Gaming, and Technology. And it's using its billions in existing assets and forecasted contributions to connect and empower the builders of the decentralized economy.
 
 Anyone can make a proposal to BitDAO and, through the governance process, BIT token holders determine the actions and direction of the organization. Since it infuses capital agnostically across industries, chains, and products, there's a great degree of flexibility in how its treasury is allocated.
 
-## An Accelerator for Autonomous Entities
+**An Accelerator for Autonomous Entities**
 Autonomous Entities (AEs) are independent organizations that are funded from successful proposals to the BitDAO treasury and are focused on a particular product, use case, or industry. Examples of previously approved Autonomous Entities include [Game7](https://game7.io/), [zkDAO](https://zkdao.io/), and [EduDAO](https://edudao.io/).
 
-## **Governance Process**
-BitDAO is owned and governed by $BIT token holders. To reduce spam, 200k BIT is required to make a proposal and 100M BIT is required to approve it.
+### **Governance Process**
+BitDAO is owned and governed by $BIT token holders. To reduce spam, 200k BIT is required to make a proposal and 100M BIT is required to approve it. 
 
-## Phase 1: Soft Proposal
+**Phase 1: Soft Proposal**
 In the Soft Proposal phase, proposals receive feedback from stakeholders in an open and informal way. This allows the proposer/proposers to make any necessary changes before an official proposal is made. The Soft Proposal phase occurs on [BitDAO's Discourse](https://discourse.bitdao.io/).
 
-## Phase 2: Snapshot Vote
-Once community feedback has been incorporated, the proposer may put the official proposal up for a vote on [BitDAO Snapshot](https://snapshot.org/#/bitdao.eth). This is the final step in the governance process.
+**Phase 2: Snapshot Vote**
+Once community feedback has been incorporated, the proposer may put the official proposal up for a vote on [BitDAO Snapshot](https://snapshot.org/#/bitdao.eth). This is the final step in the governance process. 
 
-# **Additional Resources**
+### **Additional Resources**
 * [**Website**](https://bitdao.io)
 * [**Recently Approved Proposals**](https://snapshot.org/#/bitdao.eth)
 * [**Official BitDAO Twitter**](https://twitter.com/BitDAO_Official)

--- a/protocols/bitdao/overview.md
+++ b/protocols/bitdao/overview.md
@@ -1,18 +1,18 @@
-**[BitDAO](https://www.bitdao.io/) believes DAO can do more for industries like Art, Entertainment, Finance, Technology, Entertainment, and Media. With billions in existing assets and billions in forecasted contributions BitDAO aims to support builders of the decentralized economy.**
+**[BitDAO](https://www.bitdao.io/) believes DAOs can do more for industries like Art, Education, Media, Finance, Gaming, and Technology. And it's using its billions in existing assets and forecasted contributions to connect and empower the builders of the decentralized economy.**
 
-BitDAO is an open platform for proposals that are voted upon by BIT token holders. Through the governance process BIT token holders will determine the actions and direction of BitDAO. Beceause BitDAO is chain and project agnostic it allows for a great degree of flexibility for how its treasury is allocated.
+Anyone can make a proposal to BitDAO and, through the governance process, BIT token holders determine the actions and direction of the organization. Since it infuses capital agnostically across industries, chains, and products, there's a great degree of flexibility in how its treasury is allocated.
 
-## Autonomous Entities
-Autonomous Entities (AEs) are independent organizations that are funded from successful proposals to the BitDAO treasury and are focused on a particular product, usecase, or industry. Examples of previously approved Autonomous Entities are [Game7](https://game7.io/), [zkDAO](https://zkdao.io/), or [EduDAO](https://edudao.io/).
+## An Accelerator for Autonomous Entities
+Autonomous Entities (AEs) are independent organizations that are funded from successful proposals to the BitDAO treasury and are focused on a particular product, use case, or industry. Examples of previously approved Autonomous Entities include [Game7](https://game7.io/), [zkDAO](https://zkdao.io/), and [EduDAO](https://edudao.io/).
 
 # **Governance Process**
-BitDAO is owned and governed by BIT token holders. To reduce spam 200k BIT is required to put forth a proposal and 100M BIT is required to approve it.
+BitDAO is owned and governed by $BIT token holders. To reduce spam, 200k BIT is required to make a proposal and 100M BIT is required to approve it.
 
 ## Phase 1: Soft Proposal
-The Soft Proposal phase is to receive open feedback from stakeholders about any given proposal in an open and informal way. This allows the proposer to make changes if necessary before an official proposal is made. The Soft Proposal phase occures on [BitDAO's Discourse](https://discourse.bitdao.io/).
+In the Soft Proposal phase, proposals receive feedback from stakeholders in an open and informal way. This allows the proposer/proposers to make any necessary changes before an official proposal is made. The Soft Proposal phase occurs on [BitDAO's Discourse](https://discourse.bitdao.io/).
 
 ## Phase 2: Snapshot Vote
-The Snapshot Vote is the final step in the governance process. Once community feedback has been incorporated, the proposer may put the proposal up for a vote on [BitDAO Snapshot](https://snapshot.org/#/bitdao.eth).
+Once community feedback has been incorporated, the proposer may put the official proposal up for a vote on [BitDAO Snapshot](https://snapshot.org/#/bitdao.eth). This is the final step in the governance process.
 
 # **Additional Resources**
 * [**Website**](https://bitdao.io)


### PR DESCRIPTION
- Edit overview description
- Edit blurb

Seems on the production site "BitDAO" got split in two words "bit DAO" but wasn't able to fine where is that from to do the fix.
 