### PR TITLE
disable armorfi

### DIFF
--- a/protocols/armorfi/index.json
+++ b/protocols/armorfi/index.json
@@ -7,5 +7,5 @@
     "url": "https://forum.armor.fi/",
     "categoryId" : "6"
   },
-  "isEnabled": true
+  "isEnabled": false
 }


### PR DESCRIPTION
ArmorFi rebranded to ease.org, disabling this and adding ease.org in next release

